### PR TITLE
修复print相关问题

### DIFF
--- a/src/main/java/top/mcfpp/lang/System.java
+++ b/src/main/java/top/mcfpp/lang/System.java
@@ -29,6 +29,7 @@ public class System extends MNIMethodContainer {
             //只会有一个参数哦
             if (value instanceof MCInt) print((MCInt) value);
             else if (value instanceof JsonString) print((JsonString) value);
+            else if (value instanceof MCFloat) print((MCFloat) value);
             else print(value);
             return null;
         });
@@ -48,6 +49,16 @@ public class System extends MNIMethodContainer {
             Function.Companion.addCommand("tellraw @a " + var.getJavaValue());
         }else {
             Function.Companion.addCommand("tellraw @a " + new JsonTextNumber(var).toJson());
+        }
+    }
+
+    @InsertCommand
+    public static void print(@NotNull MCFloat var) {
+        if (var.isConcrete()) {
+            //是确定的，直接输出数值
+            Function.Companion.addCommand("tellraw @a " + "\"" + var.getJavaValue() + "\"");
+        }else {
+            Function.Companion.addCommand("tellraw @a " + "\"" + var + "\"");
         }
     }
 

--- a/src/main/java/top/mcfpp/lang/System.java
+++ b/src/main/java/top/mcfpp/lang/System.java
@@ -30,6 +30,7 @@ public class System extends MNIMethodContainer {
             if (value instanceof MCInt) print((MCInt) value);
             else if (value instanceof JsonString) print((JsonString) value);
             else if (value instanceof MCFloat) print((MCFloat) value);
+            else if (value instanceof MCString) print((MCString) value);
             else print(value);
             return null;
         });
@@ -70,5 +71,20 @@ public class System extends MNIMethodContainer {
     @InsertCommand
     public static void print(@NotNull Var<?> var){
         Function.Companion.addCommand("tellraw @a " + "\"" +var + "\"");
+    }
+
+    @InsertCommand
+    public static void print(@NotNull MCString var){
+        if (var.isConcrete()) {
+            var javaValue = var.getJavaValue();
+            var text = "null";
+            if (javaValue != null) {
+                text = javaValue.getValue();
+            }
+
+            Function.Companion.addCommand("tellraw @a " + "\"" + text + "\"");
+        } else {
+            Function.Companion.addCommand("tellraw @a " + "\"" + var.toString().replaceAll("\"", "\\\\\"") + "\"");
+        }
     }
 }

--- a/src/main/java/top/mcfpp/lang/System.java
+++ b/src/main/java/top/mcfpp/lang/System.java
@@ -47,7 +47,7 @@ public class System extends MNIMethodContainer {
     public static void print(@NotNull MCInt var) {
         if (var.isConcrete()) {
             //是确定的，直接输出数值
-            Function.Companion.addCommand("tellraw @a " + var.getJavaValue());
+            Function.Companion.addCommand("tellraw @a \"" + var.getJavaValue() + "\"");
         }else {
             Function.Companion.addCommand("tellraw @a " + new JsonTextNumber(var).toJson());
         }


### PR DESCRIPTION
MC版本: 1.20.6
1. MCInt 直接打印时未包裹引号
2. MCString 打印时, 转为String后内有引号未转义。新增确定值直接打印
3. MCFloat 新增确定值直接打印