### PR TITLE
fix: calendar comparing bug

### DIFF
--- a/src/main/kotlin/top/mcfpp/util/UwU.kt
+++ b/src/main/kotlin/top/mcfpp/util/UwU.kt
@@ -65,7 +65,7 @@ object UwU {
                     "滴，编译器喵为您报时~现在是" + SimpleDateFormat("HH:mm").format(date)
                 }
             } else if (s == "疯狂星期四，vivo50") {
-                if (Calendar.DAY_OF_WEEK !== Calendar.THURSDAY) {
+                if (Calendar.getInstance().get(Calendar.DAY_OF_WEEK) != Calendar.THURSDAY) {
                     s += "。欸……什么，今天不是星期四吗（失落"
                 }
             }


### PR DESCRIPTION
Java的`Calendar.DAY_OF_WEEK`不是直接拿其常量来用的...那个是传给`get()`方法的参数，需要结合`get()`方法使用。